### PR TITLE
Improve form validation (SNAPSHOT branch)

### DIFF
--- a/app/views/createForm.scala.html
+++ b/app/views/createForm.scala.html
@@ -10,8 +10,8 @@
         
         <fieldset>
             @inputText(computerForm("name"), '_label -> "Computer name", '_help -> "")
-            @date(computerForm("introduced"), '_label -> "Introduced date", '_help -> "")
-            @date(computerForm("discontinued"), '_label -> "Discontinued date", '_help -> "")
+            @inputText(computerForm("introduced"), '_label -> "Introduced date", '_help -> "")
+            @inputText(computerForm("discontinued"), '_label -> "Discontinued date", '_help -> "")
 
             @select(
                 computerForm("company"), 

--- a/app/views/editForm.scala.html
+++ b/app/views/editForm.scala.html
@@ -11,8 +11,8 @@
         <fieldset>
         
             @inputText(computerForm("name"), '_label -> "Computer name", '_help -> "")
-            @date(computerForm("introduced"), '_label -> "Introduced date", '_help -> "")
-            @date(computerForm("discontinued"), '_label -> "Discontinued date", '_help -> "")
+            @inputText(computerForm("introduced"), '_label -> "Introduced date", '_help -> "")
+            @inputText(computerForm("discontinued"), '_label -> "Discontinued date", '_help -> "")
             
             @select(
                 computerForm("company"), 

--- a/test/FunctionalSpec.scala
+++ b/test/FunctionalSpec.scala
@@ -49,7 +49,7 @@ class FunctionalSpec extends PlaySpec with OneAppPerSuite with ScalaFutures {
 
       status(badDateFormat) must equal(BAD_REQUEST)
       contentAsString(badDateFormat) must include("""<option value="1" selected="selected">Apple Inc.</option>""")
-      contentAsString(badDateFormat) must include("""<input type="date" id="introduced" name="introduced" value="badbadbad" """)
+      contentAsString(badDateFormat) must include("""<input type="text" id="introduced" name="introduced" value="badbadbad" """)
       contentAsString(badDateFormat) must include("""<input type="text" id="name" name="name" value="FooBar" """)
 
 

--- a/test/IntegrationSpec.scala
+++ b/test/IntegrationSpec.scala
@@ -29,6 +29,12 @@ class IntegrationSpec extends PlaySpec {
         
         browser.$("section h1").first.text() must equal("Edit computer")
 
+        browser.$("#discontinued").fill().`with`("xxx")
+        browser.$("input.primary").click()
+
+        browser.$("dl.error").size must equal(1)
+        browser.$("dl.error label").first.text() must equal("Discontinued date")
+
         browser.$("#discontinued").fill().`with`("")
         browser.$("input.primary").click()
 


### PR DESCRIPTION
Two related changes are proposed:

1. date-type input elements are not supported by all browsers (see http://caniuse.com/#feat=input-datetime). After setting wrong text (e.g. "xxx") in Selenium test, Firefox sends it to the server (Firefox does not support date-type inputs), but HtmlUnit sends empty text. There are two such fields in the project - "Introduced date" and "Discontinued date" in computer creation/edition form.

2. server-side form validation testing code (in IntegrationTest) was removed accidentally(?) during project migration to Play! 2.5.x (commit https://github.com/playframework/play-scala-anorm-example/commit/248c06d7b46d642c97d8839229c4f7d6e5bc1015#diff-e1fdcc91f66decedb30d19ae54521423)

When restoring validation code, changing date-type inputs to text-type ones is required to pass any entered text to the server for server-side validation of the form.

After merging this PR, apply similar changes to master branch.