### PR TITLE
Use singleton dbexecutioncontext

### DIFF
--- a/app/models/DatabaseExecutionContext.scala
+++ b/app/models/DatabaseExecutionContext.scala
@@ -1,11 +1,13 @@
 package models
 
-import javax.inject.Inject
+import javax.inject._
 
 import akka.actor.ActorSystem
 import play.api.libs.concurrent.CustomExecutionContext
 
 /**
- *
+ * This class is a pointer to an execution context configured to point to "database.dispatcher"
+ * in the "application.conf" file.
  */
+@Singleton
 class DatabaseExecutionContext @Inject()(system: ActorSystem) extends CustomExecutionContext(system, "database.dispatcher")


### PR DESCRIPTION
Technically we don't need to do this, since looking up a dispatcher is cheap:

https://github.com/google/guice/wiki/Scopes#choosing-a-scope

but there's no need to have multiple execution context instances either...