### PR TITLE
link to playframework version of anorm

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,4 +18,4 @@ Anorm is a Scala ORM library that uses SQL:
 
 and
 
-<https://cchantep.github.io/anorm/>
+<https://playframework.github.io/anorm/>


### PR DESCRIPTION
The readme seems to be pointing to an old fork of anorm rather than the real one.