### PR TITLE
Fix deprecated WithResult.fold method usage

### DIFF
--- a/app/models/CompanyRepository.scala
+++ b/app/models/CompanyRepository.scala
@@ -35,7 +35,7 @@ class CompanyRepository @Inject()(dbapi: DBApi)(implicit ec: DatabaseExecutionCo
    */
   def options: Future[Seq[(String,String)]] = Future(db.withConnection { implicit connection =>
     SQL"select * from company order by name".
-      fold(Seq.empty[(String, String)]) { (acc, row) => // Anorm streaming
+      fold(Seq.empty[(String, String)], ColumnAliaser.empty) { (acc, row) => // Anorm streaming
         row.as(simple) match {
           case Failure(parseErr) => {
             println(s"Fails to parse $row: $parseErr")


### PR DESCRIPTION
Fixes
>Warning:(38, 7) method fold in trait WithResult is deprecated (since 2.5.1): Use `fold` with empty [[ColumnAliaser]]
>  fold(Seq.empty[(String, String)]) { (acc, row) => // Anorm streaming